### PR TITLE
Fix#15

### DIFF
--- a/generators/fix-entity/index.js
+++ b/generators/fix-entity/index.js
@@ -161,6 +161,7 @@ module.exports = generator.extend({
                 newValue = `${relationshipItem.relationshipNamePlural}_id`;
 
                 jhipsterFunc.replaceContent(files.liquibaseEntity, `\\<addPrimaryKey columnNames="${dbh.getPluralColumnIdName(this.entityTableName)}, (${columnName}|${oldValue})`, `<addPrimaryKey columnNames="${dbh.getPluralColumnIdName(this.entityTableName)}, ${newValue}`, true);
+                jhipsterFunc.replaceContent(files.liquibaseConstraints, `referencedTableName="${this.entityTableName}`, `referencedTableName="${this.tableNameInput}`);
                 jhipsterFunc.replaceContent(files.ORM, `inverseJoinColumns = @JoinColumn\\(name="(${columnName}|${oldValue})`, `inverseJoinColumns = @JoinColumn(name="${newValue}`, true);
             } else {
                 // We don't need to do anything about relationship which don't add any constraint.

--- a/generators/fix-entity/index.js
+++ b/generators/fix-entity/index.js
@@ -116,7 +116,7 @@ module.exports = generator.extend({
             const oldValue = this.dbhTableName;
             const newValue = this.tableNameInput;
 
-            updateKey(`"entityTableName": "${this.entityTableName}"`, 'dbhTableName', oldValue, newValue);
+            jhipsterFunc.updateEntityConfig(paramFiles.config, 'entityTableName', newValue);
 
             // We search either for our value or jhipster value, so it works even if user didn't accept JHipster overwrite after a regeneration
             jhipsterFunc.replaceContent(paramFiles.ORM, `@Table\\(name = "(${this.entityTableName}|${oldValue})`, `@Table(name = "${newValue}`, true);

--- a/generators/fix-entity/index.js
+++ b/generators/fix-entity/index.js
@@ -19,7 +19,6 @@ module.exports = generator.extend({
         // All information from entity generator
         this.entityConfig = this.options.entityConfig;
         this.entityTableName = this.options.entityConfig.entityTableName;
-        this.dbhTableName = this.options.entityConfig.data.dbhTableName;
         this.fields = this.options.entityConfig.data.fields;
         this.relationships = this.options.entityConfig.data.relationships;
 
@@ -111,16 +110,14 @@ module.exports = generator.extend({
             }
         };
 
-        // Add/Change/Keep dbhTableName
         const replaceTableName = (paramFiles) => {
-            const oldValue = this.dbhTableName;
             const newValue = this.tableNameInput;
 
             jhipsterFunc.updateEntityConfig(paramFiles.config, 'entityTableName', newValue);
 
             // We search either for our value or jhipster value, so it works even if user didn't accept JHipster overwrite after a regeneration
-            jhipsterFunc.replaceContent(paramFiles.ORM, `@Table\\(name = "(${this.entityTableName}|${oldValue})`, `@Table(name = "${newValue}`, true);
-            jhipsterFunc.replaceContent(paramFiles.liquibaseEntity, `\\<createTable tableName="(${this.entityTableName}|${oldValue})`, `<createTable tableName="${newValue}`, true);
+            jhipsterFunc.replaceContent(paramFiles.ORM, `@Table(name = "${this.entityTableName}`, `@Table(name = "${newValue}`);
+            jhipsterFunc.replaceContent(paramFiles.liquibaseEntity, `<createTable tableName="${this.entityTableName}`, `<createTable tableName="${newValue}`);
         };
 
         this.log(chalk.bold.yellow('writing'));
@@ -157,6 +154,8 @@ module.exports = generator.extend({
             if (relationshipItem.relationshipType === 'many-to-one' || (relationshipItem.relationshipType === 'one-to-one' && relationshipItem.ownerSide)) {
                 columnName = dbh.getColumnIdName(relationshipItem.relationshipName);
                 newValue = `${relationshipItem.relationshipName}_id`;
+
+                jhipsterFunc.replaceContent(files.liquibaseConstraints, `baseTableName="${this.entityTableName}`, `baseTableName="${this.tableNameInput}`);
             } else if (relationshipItem.relationshipType === 'many-to-many' && relationshipItem.ownerSide) {
                 columnName = dbh.getPluralColumnIdName(relationshipItem.relationshipName);
                 newValue = `${relationshipItem.relationshipNamePlural}_id`;


### PR DESCRIPTION
Now we should be able to rename tables however we want. Before that we couldn't because of constraints referencing the old value, derived from the entity name, instead of the new value, given by the user to our module.

I fixed it in three steps : 
1. Using directly `entityTableName` rather than a custom entry; the owner receives the correct information as it derives it from `otherEntityTableName`.
1. Replace `baseTableName` on the ownerside of the relationship (otm & oto)
1. Replace reference from `joinTable` to owner table (mtm).