### PR TITLE
Option --force

### DIFF
--- a/generators/fix-entity/index.js
+++ b/generators/fix-entity/index.js
@@ -138,6 +138,9 @@ module.exports = generator.extend({
         }
         this.columnsInput.forEach((columnItem) => {
             const oldValue = columnItem.dbhColumnName;
+            if(!oldValue && this.force) {
+                throw new Error('You used option --force with bad configuration file, it needs dbhColumnName for each field');
+            }
             const newValue = columnItem.columnNameInput || columnItem.dbhColumnName;
 
             updateKey(`"fieldName": "${columnItem.fieldName}"`, 'dbhColumnName', oldValue, newValue);

--- a/generators/fix-entity/index.js
+++ b/generators/fix-entity/index.js
@@ -9,7 +9,6 @@ const jhipsterVar = {
     moduleName: 'fix-entity'
 };
 
-
 const jhipsterFunc = {};
 
 
@@ -21,6 +20,7 @@ module.exports = generator.extend({
         this.entityTableName = this.options.entityConfig.entityTableName;
         this.fields = this.options.entityConfig.data.fields;
         this.relationships = this.options.entityConfig.data.relationships;
+        this.force = this.options.force;
 
         // input from user (prompts.js will fill them)
         this.tableNameInput = null;
@@ -111,7 +111,7 @@ module.exports = generator.extend({
         };
 
         const replaceTableName = (paramFiles) => {
-            const newValue = this.tableNameInput;
+            const newValue = this.tableNameInput || this.entityTableName;
 
             jhipsterFunc.updateEntityConfig(paramFiles.config, 'entityTableName', newValue);
 
@@ -133,9 +133,12 @@ module.exports = generator.extend({
         replaceTableName(files);
 
         // Add/Change/Keep dbhColumnName for each field
+        if(this.force) {
+            this.columnsInput = this.fields;
+        }
         this.columnsInput.forEach((columnItem) => {
             const oldValue = columnItem.dbhColumnName;
-            const newValue = columnItem.columnNameInput;
+            const newValue = columnItem.columnNameInput || columnItem.dbhColumnName;
 
             updateKey(`"fieldName": "${columnItem.fieldName}"`, 'dbhColumnName', oldValue, newValue);
 

--- a/generators/fix-entity/prompts.js
+++ b/generators/fix-entity/prompts.js
@@ -11,6 +11,10 @@ module.exports = {
  * Ask the table name for an entity
  */
 function askForTableName() {
+    if(this.force) {
+        return;
+    }
+
     const validateTableName = dbh.validateTableName;
     const done = this.async();
 
@@ -34,7 +38,8 @@ function askForTableName() {
 /** For each field of an entity, ask the actual column name */
 function askForColumnsName() {
     // Don't ask columns name if there aren't any field
-    if (this.fields === undefined || this.fields.length === 0) {
+    // Or option --force
+    if (this.fields === undefined || this.fields.length === 0 || this.force) {
         return;
     }
 


### PR DESCRIPTION
the post-hook generator fix-entity will now interpret the option --force from the yeoman generator. It will take the values from the files rather than from the prompt. Throw an error is such information is missing from the files.

[ci skip]