### PR TITLE
add match to previous version value (before 4.2.0, not including)

### DIFF
--- a/generators/fix-entity/index.js
+++ b/generators/fix-entity/index.js
@@ -180,8 +180,8 @@ module.exports = generator.extend({
             updateKey(`"fieldName": "${columnItem.fieldName}"`, 'dbhColumnName', oldValue, newValue);
 
             // We search either for our value or JHipster value, so it works even if user didn't accept JHipster overwrite while regenerating
-            jhipsterFunc.replaceContent(files.ORM, `@Column\\(name = "(${columnItem.fieldNameAsDatabaseColumn}|${oldValue})`, `@Column(name = "${newValue}`, true);
-            jhipsterFunc.replaceContent(files.liquibaseEntity, `\\<column name="(${columnItem.fieldNameAsDatabaseColumn}|${oldValue})`, `<column name="${newValue}`, true);
+            jhipsterFunc.replaceContent(files.ORM, `@Column\\(name = "(${columnItem.fieldNameAsDatabaseColumn}|${columnItem.fieldNameUnderscored}|${oldValue})`, `@Column(name = "${newValue}`, true);
+            jhipsterFunc.replaceContent(files.liquibaseEntity, `\\<column name="(${columnItem.fieldNameAsDatabaseColumn}|${columnItem.fieldNameUnderscored}|${oldValue})`, `<column name="${newValue}`, true);
         });
 
         // Add/Change/Keep dbhRelationshipId


### PR DESCRIPTION
The release 4.2.0 of JHipster packed a change in _Entity.java which replaced the usage of `fieldNameUnderscored` to the profit of `fieldNameAsDatabaseColumn`.This PR makes `fix-entity/index.js` to search for both. We'll do something cleaner when we'll add a JHipster version manager.