### PR TITLE
fix create-travis-case for otherEntityName

### DIFF
--- a/travis/samples/create-travis-case-from-application.sh
+++ b/travis/samples/create-travis-case-from-application.sh
@@ -198,6 +198,8 @@ while read line || [[ -n "$line" ]]; do
         cp "$entitiesDir"/"$entity".json "$entityFileNameWithId"
         # add suffix the entityTableName
         sed -i -e 's/\("entityTableName": ".*\)\(",\)/\1_'"$testCaseId"'\2/g' "$entityFileNameWithId"
+        # add suffix to the otherEntityNames
+        sed -i -e 's/\("otherEntityName": ".*\)\(",\)/\1_'"$testCaseId"'\2/g' "$entityFileNameWithId"
     fi
 
     echo "$entityNameWithId" >> "$mocksConfigurationFile"


### PR DESCRIPTION
otherEntityName wasn't correctly handled for the generated mocks because
it linked to the table without the test case suffix