### PR TITLE
ask for relationship column name

### DIFF
--- a/generators/fix-entity/index.js
+++ b/generators/fix-entity/index.js
@@ -32,7 +32,7 @@ module.exports = class extends BaseGenerator {
                 // All information from entity generator
                 this.entityTableName = this.entityConfig.entityTableName;
                 this.entityClass = this.entityConfig.entityClass;
-                this.dbhIdName = this.entityConfig.data.dbhIdName || "id";
+                this.dbhIdName = this.entityConfig.data.dbhIdName || 'id';
                 this.fields = this.entityConfig.data.fields;
                 this.relationships = this.entityConfig.data.relationships;
 
@@ -188,11 +188,11 @@ module.exports = class extends BaseGenerator {
             }
 
             const otherEntity = JSON.parse(fs.readFileSync(`${this.entityConfig.jhipsterConfigDirectory}/${relationshipItem.otherEntityNameCapitalized}.json`, 'utf8'));
-            const otherEntityIdName = otherEntity.dbhIdName || "id";
+            const otherEntityIdName = otherEntity.dbhIdName || 'id';
             const oldValue = relationshipItem.dbhRelationshipId;
 
             let columnName = null;
-            let newValue = relationshipItem.relationshipIdInput || relationshipItem.dbhRelationshipId || `${relationshipItem.relationshipName}_id`;
+            const newValue = relationshipItem.relationshipIdInput || relationshipItem.dbhRelationshipId || `${relationshipItem.relationshipName}_id`;
             let initialTableIdName = null;
 
 

--- a/generators/fix-entity/index.js
+++ b/generators/fix-entity/index.js
@@ -32,7 +32,7 @@ module.exports = class extends BaseGenerator {
                 // All information from entity generator
                 this.entityTableName = this.entityConfig.entityTableName;
                 this.entityClass = this.entityConfig.entityClass;
-                this.dbhIdName = this.entityConfig.data.dbhIdName;
+                this.dbhIdName = this.entityConfig.data.dbhIdName || "id";
                 this.fields = this.entityConfig.data.fields;
                 this.relationships = this.entityConfig.data.relationships;
 
@@ -188,6 +188,7 @@ module.exports = class extends BaseGenerator {
             }
 
             const otherEntity = JSON.parse(fs.readFileSync(`${this.entityConfig.jhipsterConfigDirectory}/${relationshipItem.otherEntityNameCapitalized}.json`, 'utf8'));
+            const otherEntityIdName = otherEntity.dbhIdName || "id";
             const oldValue = relationshipItem.dbhRelationshipId;
 
             let columnName = null;
@@ -199,7 +200,7 @@ module.exports = class extends BaseGenerator {
                 columnName = dbh.getColumnIdName(relationshipItem.relationshipName);
 
                 this.replaceContent(files.liquibaseConstraints, `baseTableName="${this.entityTableName}`, `baseTableName="${this.tableNameInput}`);
-                this.replaceContent(files.liquibaseConstraints, `(referencedColumnNames=")id("\\s*referencedTableName="${otherEntity.entityTableName}")`, `$1${otherEntity.dbhIdName}$2`, true);
+                this.replaceContent(files.liquibaseConstraints, `(referencedColumnNames=")id("\\s*referencedTableName="${otherEntity.entityTableName}")`, `$1${otherEntityIdName}$2`, true);
 
                 if (relationshipItem.relationshipType === 'many-to-one') {
                     /**
@@ -220,7 +221,7 @@ module.exports = class extends BaseGenerator {
                 this.replaceContent(files.ORM, `inverseJoinColumns = @JoinColumn\\(name="(${columnName}|${oldValue})`, `inverseJoinColumns = @JoinColumn(name="${newValue}`, true);
                 this.replaceContent(files.liquibaseConstraints, `(referencedColumnNames=")id("\\s*referencedTableName="${this.entityTableName}")`, `$1${this.idNameInput}$2`, true);
                 // todo duplicate line, will remove on refactoring (duplicate with l258 as of the commit bringing this up)
-                this.replaceContent(files.liquibaseConstraints, `(referencedColumnNames=")id("\\s*referencedTableName="${otherEntity.entityTableName}")`, `$1${otherEntity.dbhIdName}$2`, true);
+                this.replaceContent(files.liquibaseConstraints, `(referencedColumnNames=")id("\\s*referencedTableName="${otherEntity.entityTableName}")`, `$1${otherEntityIdName}$2`, true);
                 this.replaceContent(files.ORM, `(@JoinColumn\\(name="${initialTableIdName}", referencedColumnName=")id`, `$1${this.idNameInput}`, true);
                 this.replaceContent(files.ORM, `(inverseJoinColumns = @JoinColumn\\(name="${newValue}", referencedColumnName=")id`, `$1${otherEntity.dbhIdName}`, true);
             }

--- a/generators/fix-entity/prompts.js
+++ b/generators/fix-entity/prompts.js
@@ -4,7 +4,8 @@ const dbh = require('../dbh.js');
 module.exports = {
     askForTableName,
     askForIdName,
-    askForColumnsName
+    askForColumnsName,
+    askForRelationshipsId
 };
 
 /**
@@ -113,6 +114,74 @@ function askForColumnName(done) {
 
         if (this.field !== undefined) {
             askForColumnName.call(this, done);
+        } else {
+            done();
+        }
+    });
+}
+
+/** For each relationship of entity, ask for actual column name */
+function askForRelationshipsId() {
+    // Don't ask relationship id if there aren't any relationship
+    // Or option --force
+    if (this.relationships === undefined || this.relationships.length === 0 || this.force) {
+        return;
+    }
+
+    // work only on owner relationship
+    this.relationshipsPile = this.relationships.filter((relationshipItem) => {
+        // We don't need to do anything about relationships which don't add any constraint.
+        return !(relationshipItem.relationshipType === 'one-to-many' ||
+            (relationshipItem.relationshipType === 'one-to-one' && !relationshipItem.ownerSide) ||
+            (relationshipItem.relationshipType === 'many-to-many' && !relationshipItem.ownerSide));
+    });
+
+    if (this.relationshipsPile.length === 0) {
+        return;
+    }
+
+    this.log(chalk.green(`Asking column names for ${this.relationshipsPile.length} relationship(s)`));
+    const done = this.async();
+    
+    this.relationship = this.relationshipsPile.pop();
+    askForRelationshipId.call(this, done);
+}
+
+/**
+ * Use ${this.relationship} which is set either by askForRelationshipsId or previous recursive call
+ *
+ * Ask the column name for the relationship of an entity
+ * This function use ${this.relationshipsPile}, at each call it will pop an item from it and ask its question about it.
+ * Then it will associate the answer with this item and push it to ${this.relationshipsInput}.
+ * So at the end of the recursion, ${this.relationshipsPile} will be empty and this.relationshipsInput full with what was in the former.
+ */
+function askForRelationshipId(done) {
+    const validateColumnName = dbh.validateColumnName;
+    const defaultAnswer = this.relationship.dbhRelationshipId || `${this.relationship.relationshipName}_id`;
+
+    const prompts = [
+        {
+            type: 'input',
+            name: 'dbhRelationshipId',
+            validate: ((input) => {
+                const prodDatabaseType = this.jhipsterAppConfig.prodDatabaseType;
+                return validateColumnName(input, prodDatabaseType);
+            }),
+            message: `What column name do you want for the relationship "${this.relationship.relationshipName}" ?`,
+            default: defaultAnswer
+        }
+    ];
+
+    this.prompt(prompts).then((props) => {
+        this.relationship.relationshipIdInput = props.dbhRelationshipId;
+
+        // push just processed item
+        this.relationshipsInput.push(this.relationship);
+        // pop item for next recursion
+        this.relationship = this.relationshipsPile.pop();
+
+        if (this.relationship !== undefined) {
+            askForRelationshipId.call(this, done);
         } else {
             done();
         }

--- a/generators/fix-entity/prompts.js
+++ b/generators/fix-entity/prompts.js
@@ -129,12 +129,11 @@ function askForRelationshipsId() {
     }
 
     // work only on owner relationship
-    this.relationshipsPile = this.relationships.filter((relationshipItem) => {
+    this.relationshipsPile = this.relationships.filter(relationshipItem =>
         // We don't need to do anything about relationships which don't add any constraint.
-        return !(relationshipItem.relationshipType === 'one-to-many' ||
+        !(relationshipItem.relationshipType === 'one-to-many' ||
             (relationshipItem.relationshipType === 'one-to-one' && !relationshipItem.ownerSide) ||
-            (relationshipItem.relationshipType === 'many-to-many' && !relationshipItem.ownerSide));
-    });
+            (relationshipItem.relationshipType === 'many-to-many' && !relationshipItem.ownerSide)));
 
     if (this.relationshipsPile.length === 0) {
         return;
@@ -142,7 +141,7 @@ function askForRelationshipsId() {
 
     this.log(chalk.green(`Asking column names for ${this.relationshipsPile.length} relationship(s)`));
     const done = this.async();
-    
+
     this.relationship = this.relationshipsPile.pop();
     askForRelationshipId.call(this, done);
 }


### PR DESCRIPTION
This PR is related to relationships.
1. Add question about relationship column names, so you can change default relationship column name to others. It's helpful in some cases.
2. Add default reference column name `id`. It happen when you use this module for existed application. You create new entity, that has relationship with existed entities. The output will be `undefined`. Just fix the bug.

Hope this will be merged.
Thanks

Regards,
Tien Tran