### PR TITLE
Update README.md - remove unnecessary prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ However some of us still want create a JHipster applications with such databases
 
 2. Run the main generator on your already created JHipster application.
 
-`yo generator-jhipster-db-helper`
+`yo jhipster-db-helper`
 
 3. Answer our module's questions after creating or regenerating an entity
 


### PR DESCRIPTION
Remove prefix because of this CLI message when running `yo generator-jhipster-db-helper`:
```
In the future, run yo jhipster-db-helper instead!

Error generator-jhipster-db-helper

You don't seem to have a generator with the name “jhipster-db-helper” installed.
```